### PR TITLE
fix: O2 Sat 10m Avg reporting `255%`

### DIFF
--- a/custom_components/owlet/sensor.py
+++ b/custom_components/owlet/sensor.py
@@ -157,6 +157,12 @@ class OwletSensor(OwletBaseEntity, SensorEntity):
         if self.entity_description.key == "sleep_state":
             return SLEEP_STATES[self.sock.properties["sleep_state"]]
 
+        if self.entity_description.key == "oxygen_10_av":
+            val = self.sock.properties[self.entity_description.key]
+            if val is None or not isinstance(val, (int, float)) or val < 0 or val > 100:
+                return None
+            return val
+
         return self.sock.properties[self.entity_description.key]
 
     @property


### PR DESCRIPTION
Just a suggestion!

The O2 Sat 10m average reports `255%` when not charging, and before it can calculate the 10m average. Suggest changing to report `None` until the average can be displayed. This way the graphs/data aren't skewed by the 255 value.