### PR TITLE
(Fixed) Ensure entities from multiple Owlet devices register correctly

### DIFF
--- a/custom_components/owlet/binary_sensor.py
+++ b/custom_components/owlet/binary_sensor.py
@@ -106,11 +106,11 @@ async def async_setup_entry(
 
     sensors = []
     for coordinator in coordinators:
-        sensors = [
+        sensors.extend([
             OwletBinarySensor(coordinator, sensor)
             for sensor in SENSORS
             if sensor.key in coordinator.sock.properties
-        ]
+        ])
 
         if OwletAwakeSensor.entity_description.key in coordinator.sock.properties:
             sensors.append(OwletAwakeSensor(coordinator))

--- a/custom_components/owlet/entity.py
+++ b/custom_components/owlet/entity.py
@@ -19,6 +19,7 @@ class OwletBaseEntity(CoordinatorEntity[OwletCoordinator], Entity):
     ) -> None:
         """Initialize the base entity."""
         super().__init__(coordinator)
+        self.coordinator = coordinator
         self.sock = coordinator.sock
 
     @property
@@ -26,9 +27,12 @@ class OwletBaseEntity(CoordinatorEntity[OwletCoordinator], Entity):
         """Return the device info of the device."""
         return DeviceInfo(
             identifiers={(DOMAIN, self.sock.serial)},
-            name="Owlet Baby Care Sock",
-            manufacturer=MANUFACTURER,
-            model=self.sock.model,
-            sw_version=self.sock.sw_version,
-            hw_version=f"{self.sock.version}r{self.sock.revision}",
+            name=f"Owlet Sock {self.sock.serial}",
+            connections={("mac", getattr(self.sock, "mac", "unknown"))},
+            suggested_area="Nursery",
+            configuration_url="https://my.owletcare.com/",
+            manufacturer="Owlet Baby Care",
+            model=getattr(self.sock, "model", None),
+            sw_version=getattr(self.sock, "sw_version", None),
+            hw_version=getattr(self.sock, "hw_version", "3r8"),
         )

--- a/custom_components/owlet/sensor.py
+++ b/custom_components/owlet/sensor.py
@@ -115,11 +115,11 @@ async def async_setup_entry(
     sensors = []
 
     for coordinator in coordinators:
-        sensors = [
+        sensors.extend([
             OwletSensor(coordinator, sensor)
             for sensor in SENSORS
             if sensor.key in coordinator.sock.properties
-        ]
+        ])
 
         if OwletSleepSensor.entity_description.key in coordinator.sock.properties:
             sensors.append(OwletSleepSensor(coordinator))

--- a/custom_components/owlet/switch.py
+++ b/custom_components/owlet/switch.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
 
     switches = []
     for coordinator in coordinators:
-        switches = [OwletBaseSwitch(coordinator, switch) for switch in SWITCHES]
+        switches.extend([OwletBaseSwitch(coordinator, switch) for switch in SWITCHES])
     async_add_entities(switches)
 
 


### PR DESCRIPTION
This addresses a bug preventing entities from multiple Owlet devices from being correctly registered within Home Assistant. The fix ensures that all sensors, binary sensors, and switches from all configured Owlet devices are properly added by correcting the list handling during setup. Additionally, device information handling within the base entity has been refined for better accuracy and robustness.